### PR TITLE
feat(cli): add `--max-prob` setting alongside `--min-prob`

### DIFF
--- a/crates/cli/src/trending_tui/state/yield_state.rs
+++ b/crates/cli/src/trending_tui/state/yield_state.rs
@@ -36,6 +36,7 @@ pub struct YieldState {
     pub scroll: usize,
     pub is_loading: bool,
     pub min_prob: f64,
+    pub max_prob: f64,
     pub min_volume: f64,
     pub sort_by: YieldSortBy,
     pub filter_query: String, // Current filter query
@@ -81,6 +82,7 @@ impl YieldState {
             scroll: 0,
             is_loading: false,
             min_prob: 0.95,
+            max_prob: 1.0,
             min_volume: 0.0,
             sort_by: YieldSortBy::Return,
             filter_query: String::new(),


### PR DESCRIPTION
Use case: I want to find high-probability yield opportunities, but need them to be sufficiently high-yield (i.e., not 99.9%, with basically 0 return). Easy refactor. 